### PR TITLE
Build libOpenCOR and its third-party libraries for macOS 10.13 and later

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,14 +32,16 @@ if(NOT RESULT EQUAL 0)
     message(FATAL_ERROR "Git submodules could not be retrieved.")
 endif()
 
-# Enable C++11 which, on macOS, means that we can deploy on OS X 10.9 and later.
+# Enable C++11.
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# On macOS, deploy on macOS 10.13 and later.
+
 if(APPLE AND "${CMAKE_OSX_DEPLOYMENT_TARGET}" STREQUAL "")
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
 endif()
 
 # Some common CMake functions/macros.

--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -256,6 +256,12 @@ if(CMAKE_C_COMPILER_LAUNCHER AND CMAKE_CXX_COMPILER_LAUNCHER)
     )
 endif()
 
+if(APPLE)
+    list(APPEND CMAKE_ARGS
+        -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+    )
+endif()
+
 # Get ready to use nmake/make for some third-party libraries (e.g., OpenSSL).
 
 if(WIN32)

--- a/src/3rdparty/CMakeLists.txt
+++ b/src/3rdparty/CMakeLists.txt
@@ -25,7 +25,7 @@ add_subdirectory(zlib)
 
 add_subdirectory(libSBML) # Requires libxml2.
 
-add_subdirectory(libNuML) # Requires libSBML (and libxml2).
+add_subdirectory(libNuML) # Requires libSBML and libxml2.
 
 # Required third-party libraries.
 

--- a/src/3rdparty/OpenSSL/CMakeLists.txt
+++ b/src/3rdparty/OpenSSL/CMakeLists.txt
@@ -49,10 +49,10 @@ if(LIBOPENCOR_PREBUILT_OPENSSL)
     elseif(APPLE)
         retrieve_package(${PACKAGE_NAME} ${PACKAGE_VERSION}
                          ${PACKAGE_REPOSITORY} ${RELEASE_TAG}
-                         dc863a1aa7b310c6ab27d1b740f7d50838e85086
+                         43b19276d82b8835332e0d274d8baeccc3cce5d1
                          SHA1_FILES ${SHA1_FILES}
-                         SHA1_VALUES ee1b0d58ed6dd8be5c7014e0d4517dd376458428
-                                     4da4b3295ff7e8c47be5b66c1b1814e0db1fd617)
+                         SHA1_VALUES 25fade4fec3b03e0f52aad81c924535d5d7cdd96
+                                     c43d1543d6361a8a07d7166ba4976baca3662837)
     else()
         retrieve_package(${PACKAGE_NAME} ${PACKAGE_VERSION}
                          ${PACKAGE_REPOSITORY} ${RELEASE_TAG}

--- a/src/3rdparty/libCellML/CMakeLists.txt
+++ b/src/3rdparty/libCellML/CMakeLists.txt
@@ -84,6 +84,9 @@ else()
             -DZLIB_ROOT=${ZLIB_ROOT}
         BUILD_BYPRODUCTS
             ${INSTALL_DIR}/${STATIC_LIBRARY}
+        DEPENDS
+            libxml2
+            zlib
     )
 
     create_package(${PACKAGE_NAME} ${PACKAGE_VERSION}

--- a/src/3rdparty/libCellML/CMakeLists.txt
+++ b/src/3rdparty/libCellML/CMakeLists.txt
@@ -49,9 +49,9 @@ if(LIBOPENCOR_PREBUILT_LIBCELLML)
     elseif(APPLE)
         retrieve_package(${PACKAGE_NAME} ${PACKAGE_VERSION}
                          ${PACKAGE_REPOSITORY} ${RELEASE_TAG}
-                         893d3cf69c720c693af1659b0319efb846703cea
+                         95d9d1105dde075988a0083f188fde859ab43248
                          SHA1_FILES ${SHA1_FILES}
-                         SHA1_VALUES 196898a324bdc45ca5a6baca1e99d5075b1c270f)
+                         SHA1_VALUES 60ae23588adba6c3456907d67c277cfb97ca05b0)
     else()
         retrieve_package(${PACKAGE_NAME} ${PACKAGE_VERSION}
                          ${PACKAGE_REPOSITORY} ${RELEASE_TAG}

--- a/src/3rdparty/libNuML/CMakeLists.txt
+++ b/src/3rdparty/libNuML/CMakeLists.txt
@@ -45,9 +45,9 @@ if(LIBOPENCOR_PREBUILT_LIBNUML)
     elseif(APPLE)
         retrieve_package(${PACKAGE_NAME} ${PACKAGE_VERSION}
                          ${PACKAGE_REPOSITORY} ${RELEASE_TAG}
-                         ba4d284d4fd761c6c7c22ad0caf29dedb06a41d8
+                         e507c6d61a3061576782feca508af83def585d22
                          SHA1_FILES ${SHA1_FILES}
-                         SHA1_VALUES a3e85c78909012f61a10df6d2341fb2da5633cba)
+                         SHA1_VALUES 1da15183b4759b48d74903724530b412c1107878)
     else()
         retrieve_package(${PACKAGE_NAME} ${PACKAGE_VERSION}
                          ${PACKAGE_REPOSITORY} ${RELEASE_TAG}

--- a/src/3rdparty/libNuML/CMakeLists.txt
+++ b/src/3rdparty/libNuML/CMakeLists.txt
@@ -85,6 +85,9 @@ else()
             -DWITH_SWIG=OFF
         BUILD_BYPRODUCTS
             ${INSTALL_DIR}/${STATIC_LIBRARY}
+        DEPENDS
+            libSBML
+            libxml2
     )
 
     create_package(${PACKAGE_NAME} ${PACKAGE_VERSION}

--- a/src/3rdparty/libSBML/CMakeLists.txt
+++ b/src/3rdparty/libSBML/CMakeLists.txt
@@ -45,9 +45,9 @@ if(LIBOPENCOR_PREBUILT_LIBSBML)
     elseif(APPLE)
         retrieve_package(${PACKAGE_NAME} ${PACKAGE_VERSION}
                          ${PACKAGE_REPOSITORY} ${RELEASE_TAG}
-                         de7caa9e16ff4e30b5a64d96bf34c5c49a251f65
+                         e65e2402660de7b3b33c67e345e2c57d6b098699
                          SHA1_FILES ${SHA1_FILES}
-                         SHA1_VALUES 4d08de8699bf7db9263e2fc71482c46cdf03db26)
+                         SHA1_VALUES 2a4d8fa86b159318c59ac0218968b09f77dbfd07)
     else()
         retrieve_package(${PACKAGE_NAME} ${PACKAGE_VERSION}
                          ${PACKAGE_REPOSITORY} ${RELEASE_TAG}

--- a/src/3rdparty/libSBML/CMakeLists.txt
+++ b/src/3rdparty/libSBML/CMakeLists.txt
@@ -75,6 +75,8 @@ else()
             -DWITH_ZLIB=OFF
         BUILD_BYPRODUCTS
             ${INSTALL_DIR}/${STATIC_LIBRARY}
+        DEPENDS
+            libxml2
     )
 
     create_package(${PACKAGE_NAME} ${PACKAGE_VERSION}

--- a/src/3rdparty/libcurl/CMakeLists.txt
+++ b/src/3rdparty/libcurl/CMakeLists.txt
@@ -49,9 +49,9 @@ if(LIBOPENCOR_PREBUILT_LIBCURL)
     elseif(APPLE)
         retrieve_package(${PACKAGE_NAME} ${PACKAGE_VERSION}
                          ${PACKAGE_REPOSITORY} ${RELEASE_TAG}
-                         34a35493797ae85a8607e691ac1e687ca2dec550
+                         880b4d6e06772ef79831b2f2e20bae3eaf2aba13
                          SHA1_FILES ${SHA1_FILES}
-                         SHA1_VALUES cc3e922325223f7f4a8b56f6af7ec42a3f0f3f8d)
+                         SHA1_VALUES ee52e27f3b1f2de57034437ae1dc8fb91e5f108e)
     else()
         retrieve_package(${PACKAGE_NAME} ${PACKAGE_VERSION}
                          ${PACKAGE_REPOSITORY} ${RELEASE_TAG}

--- a/src/3rdparty/libcurl/CMakeLists.txt
+++ b/src/3rdparty/libcurl/CMakeLists.txt
@@ -78,6 +78,8 @@ else()
             -DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR}
         BUILD_BYPRODUCTS
             ${INSTALL_DIR}/${STATIC_LIBRARY}
+        DEPENDS
+            OpenSSL
     )
 
     create_package(${PACKAGE_NAME} ${PACKAGE_VERSION}

--- a/src/3rdparty/libxml2/CMakeLists.txt
+++ b/src/3rdparty/libxml2/CMakeLists.txt
@@ -53,9 +53,9 @@ if(LIBOPENCOR_PREBUILT_LIBXML2)
     elseif(APPLE)
         retrieve_package(${PACKAGE_NAME} ${PACKAGE_VERSION}
                          ${PACKAGE_REPOSITORY} ${RELEASE_TAG}
-                         6d3be28a779c4028ecec7e543d0464cb3dfbd904
+                         06178306e9fcb9b0ac4981fddc2d0aa7f3b7fec0
                          SHA1_FILES ${SHA1_FILES}
-                         SHA1_VALUES 2d7e391563a662035ca9ca2817e0ec1b45fb9221)
+                         SHA1_VALUES bf3c4512630a1621697cbe30ce9a09f95dcec398)
     else()
         retrieve_package(${PACKAGE_NAME} ${PACKAGE_VERSION}
                          ${PACKAGE_REPOSITORY} ${RELEASE_TAG}

--- a/src/3rdparty/zlib/CMakeLists.txt
+++ b/src/3rdparty/zlib/CMakeLists.txt
@@ -53,9 +53,9 @@ if(LIBOPENCOR_PREBUILT_ZLIB)
     elseif(APPLE)
         retrieve_package(${PACKAGE_NAME} ${PACKAGE_VERSION}
                          ${PACKAGE_REPOSITORY} ${RELEASE_TAG}
-                         bb08e24bcf5c88fe218f0d63684262a4dfa2e54e
+                         e8070b1f887d485f028d103c784631e773cf7f74
                          SHA1_FILES ${SHA1_FILES}
-                         SHA1_VALUES 2e57232a8559f3c2dc68db61c2f81b99e74a0e63)
+                         SHA1_VALUES 2f6446c09a295410425cb48152eb6cda36b4d6db)
     else()
         retrieve_package(${PACKAGE_NAME} ${PACKAGE_VERSION}
                          ${PACKAGE_REPOSITORY} ${RELEASE_TAG}


### PR DESCRIPTION
Fixes #32.