### PR TITLE
File: use `std::vector<unsigned char>` rather than `char *` for the contents of a file

### DIFF
--- a/src/3rdparty/LLVMClang/llvmbegin.h
+++ b/src/3rdparty/LLVMClang/llvmbegin.h
@@ -67,6 +67,7 @@ limitations under the License.
 #    pragma clang diagnostic ignored "-Wswitch-enum"
 #    pragma clang diagnostic ignored "-Wtautological-type-limit-compare"
 #    pragma clang diagnostic ignored "-Wundefined-func-template"
+#    pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #    pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #    pragma clang diagnostic ignored "-Wunused-parameter"
 #    pragma clang diagnostic ignored "-Wweak-vtables"

--- a/src/api/libopencor/file.h
+++ b/src/api/libopencor/file.h
@@ -92,7 +92,7 @@ public:
      * ```
      *
      * @param pFileNameOrUrl The @c std::string file name or URL.
-     * @param pContents The raw contents of the virtual file as @c std::vector of unsigned @c char.
+     * @param pContents The raw contents of the virtual file as a @c std::vector of unsigned @c char.
      *
      * @return A smart pointer to a @ref File object.
      */

--- a/src/api/libopencor/file.h
+++ b/src/api/libopencor/file.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "libopencor/types.h"
 
 #include <string>
+#include <vector>
 
 namespace libOpenCOR {
 
@@ -69,7 +70,7 @@ public:
      *
      * ```
      * auto localFile = libOpenCOR::File::create("/some/path/file.txt");
-     * auto remoteFile = libOpenCOR::File::create("https://domain.com/file.txt");
+     * auto remoteFile = libOpenCOR::File::create("https://some.domain.com/file.txt");
      * ```
      *
      * @param pFileNameOrUrl The @c std::string file name or URL.
@@ -86,18 +87,17 @@ public:
      * Factory method to create a @ref File object for a virtual file:
      *
      * ```
-     * auto localVirtualFile = libOpenCOR::File::create("/some/path/file.txt", "Some contents...", 16);
-     * auto remoteVirtualFile = libOpenCOR::File::create("https://domain.com/file.txt", "Some contents...", 16);
+     * auto localVirtualFile = libOpenCOR::File::create("/some/path/file.txt", someContents);
+     * auto remoteVirtualFile = libOpenCOR::File::create("https://some.domain.com/file.txt", someContents);
      * ```
      *
      * @param pFileNameOrUrl The @c std::string file name or URL.
-     * @param pContents The raw contents of the virtual file.
-     * @param pSize The size of the raw contents of the virtual file.
+     * @param pContents The raw contents of the virtual file as @c std::vector of unsigned @c char.
      *
      * @return A smart pointer to a @ref File object.
      */
 
-    static FilePtr create(const std::string &pFileNameOrUrl, const char *pContents, size_t pSize);
+    static FilePtr create(const std::string &pFileNameOrUrl, const std::vector<unsigned char> &pContents);
 
     /**
      * @brief Get the type of this file.
@@ -141,20 +141,10 @@ public:
     emscripten::val jsContents() const;
 #endif
 
-    const char *contents() const;
-
-    /**
-     * @brief Return the size of this file.
-     *
-     * Return the size of this file.
-     *
-     * @return The size, as a @c size_t, of this file.
-     */
-
-    size_t size() const;
+    std::vector<unsigned char> contents() const;
 
 private:
-    explicit File(const std::string &pFileNameOrUrl, const char *pContents = nullptr, size_t pSize = 0); /**< Constructor @private*/
+    explicit File(const std::string &pFileNameOrUrl, const std::vector<unsigned char> &pContents = {}); /**< Constructor @private*/
 
     struct Impl; /**< Forward declaration of the implementation class, @private. */
 

--- a/src/bindings/javascript/file.cpp
+++ b/src/bindings/javascript/file.cpp
@@ -27,13 +27,13 @@ EMSCRIPTEN_BINDINGS(libOpenCOR_File)
 
     emscripten::class_<libOpenCOR::File>("File")
         .smart_ptr_constructor("File", emscripten::optional_override([](const std::string &pFileNameOrUrl, uintptr_t pContents, size_t pSize) {
-                                   return libOpenCOR::File::create(pFileNameOrUrl, reinterpret_cast<char *>(pContents), pSize);
+                                   return libOpenCOR::File::create(pFileNameOrUrl,
+                                                                   std::vector<unsigned char>(reinterpret_cast<unsigned char *>(pContents), reinterpret_cast<unsigned char *>(pContents) + pSize));
                                }))
         .function("type", &libOpenCOR::File::type)
         .function("fileName", &libOpenCOR::File::fileName)
         .function("url", &libOpenCOR::File::url)
-        .function("contents", &libOpenCOR::File::jsContents)
-        .function("size", &libOpenCOR::File::size);
+        .function("contents", &libOpenCOR::File::jsContents);
 
     EM_ASM({
         Module['File']['Type'] = Module['File.Type'];

--- a/src/bindings/javascript/file.cpp
+++ b/src/bindings/javascript/file.cpp
@@ -27,8 +27,10 @@ EMSCRIPTEN_BINDINGS(libOpenCOR_File)
 
     emscripten::class_<libOpenCOR::File>("File")
         .smart_ptr_constructor("File", emscripten::optional_override([](const std::string &pFileNameOrUrl, uintptr_t pContents, size_t pSize) {
+                                   auto contents = reinterpret_cast<unsigned char *>(pContents);
+
                                    return libOpenCOR::File::create(pFileNameOrUrl,
-                                                                   std::vector<unsigned char>(reinterpret_cast<unsigned char *>(pContents), reinterpret_cast<unsigned char *>(pContents) + pSize));
+                                                                   std::vector<unsigned char>(contents, contents + pSize));
                                }))
         .function("type", &libOpenCOR::File::type)
         .function("fileName", &libOpenCOR::File::fileName)

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -20,7 +20,9 @@ set(PYTHON_BINDINGS_DIR ${CMAKE_BINARY_DIR}/tests/bindings/python CACHE INTERNAL
 
 set(PYTHON_BINDINGS_TARGET ${CMAKE_PROJECT_NAME}_Python CACHE INTERNAL "Python bindings target.")
 set(PYTHON_SOURCE_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/python.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/file.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/version.cpp
     CACHE INTERNAL "Python source files."
 )
 

--- a/src/bindings/python/file.cpp
+++ b/src/bindings/python/file.cpp
@@ -23,19 +23,8 @@ limitations under the License.
 
 namespace py = pybind11;
 
-#define STRINGIFY(x) #x
-#define MACRO_STRINGIFY(x) STRINGIFY(x)
-
-PYBIND11_MODULE(module, m)
+void fileApi(py::module_ &m)
 {
-    // Version.
-
-    m.attr("__version__") = MACRO_STRINGIFY(PROJECT_VERSION);
-
-    // Documentation.
-
-    m.doc() = "libOpenCOR is the backend library to OpenCOR, an open source cross-platform modelling environment.";
-
     // File API.
 
     py::class_<libOpenCOR::File, std::shared_ptr<libOpenCOR::File>> file(m, "File");
@@ -54,23 +43,4 @@ PYBIND11_MODULE(module, m)
         .def_property_readonly("file_name", &libOpenCOR::File::fileName, "Get the file name for this File object.")
         .def_property_readonly("url", &libOpenCOR::File::url, "Get the URL for this File object.")
         .def_property_readonly("contents", &libOpenCOR::File::contents, "Get the contents of this File object.");
-
-    // Version API.
-
-    m.def("version", &libOpenCOR::version, "Get the version number of libOpenCOR.");
-    m.def("version_string", &libOpenCOR::versionString, "Get the version string of libOpenCOR.");
-    m.def("clang_version", &libOpenCOR::clangVersion, "Get the version number of Clang.");
-    m.def("clang_version_string", &libOpenCOR::clangVersionString, "Get the version string of Clang.");
-    m.def("libcellml_version", &libOpenCOR::libcellmlVersion, "Get the version number of libCellML.");
-    m.def("libcellml_version_string", &libOpenCOR::libcellmlVersionString, "Get the version string of libCellML.");
-    m.def("libcombine_version", &libOpenCOR::libcombineVersion, "Get the version number of libCOMBINE.");
-    m.def("libcombine_version_string", &libOpenCOR::libcombineVersionString, "Get the version string of libCOMBINE.");
-    m.def("libcurl_version", &libOpenCOR::libcurlVersion, "Get the version number of libcurl.");
-    m.def("libcurl_version_string", &libOpenCOR::libcurlVersionString, "Get the version string of libcurl.");
-    m.def("libsedml_version", &libOpenCOR::libsedmlVersion, "Get the version number of libSEDML.");
-    m.def("libsedml_version_string", &libOpenCOR::libsedmlVersionString, "Get the version string of libSEDML.");
-    m.def("llvm_version", &libOpenCOR::llvmVersion, "Get the version number of LLVM.");
-    m.def("llvm_version_string", &libOpenCOR::llvmVersionString, "Get the version string of LLVM.");
-    m.def("sundials_version", &libOpenCOR::sundialsVersion, "Get the version number of SUNDIALS.");
-    m.def("sundials_version_string", &libOpenCOR::sundialsVersionString, "Get the version string of SUNDIALS.");
 }

--- a/src/bindings/python/main.cpp
+++ b/src/bindings/python/main.cpp
@@ -1,0 +1,43 @@
+/*
+Copyright libOpenCOR contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <libopencor>
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+#define STRINGIFY(x) #x
+#define MACRO_STRINGIFY(x) STRINGIFY(x)
+
+void fileApi(py::module_ &m);
+void versionApi(py::module_ &m);
+
+PYBIND11_MODULE(module, m)
+{
+    // Version.
+
+    m.attr("__version__") = MACRO_STRINGIFY(PROJECT_VERSION);
+
+    // Documentation.
+
+    m.doc() = "libOpenCOR is the backend library to OpenCOR, an open source cross-platform modelling environment.";
+
+    // APIs.
+
+    fileApi(m);
+    versionApi(m);
+}

--- a/src/bindings/python/python.cpp
+++ b/src/bindings/python/python.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include <libopencor>
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 
@@ -48,12 +49,11 @@ PYBIND11_MODULE(module, m)
         .export_values();
 
     file.def(py::init(py::overload_cast<const std::string &>(&libOpenCOR::File::create)), "Create a File object.", py::arg("file_name_or_url"))
-        .def(py::init(py::overload_cast<const std::string &, const char *, size_t>(&libOpenCOR::File::create)), "Create a File object.", py::arg("file_name_or_url"), py::arg("contents"), py::arg("size"))
+        .def(py::init(py::overload_cast<const std::string &, const std::vector<unsigned char> &>(&libOpenCOR::File::create)), "Create a File object.", py::arg("file_name_or_url"), py::arg("contents"))
         .def_property_readonly("type", &libOpenCOR::File::type, "Get the type of this File object.")
         .def_property_readonly("file_name", &libOpenCOR::File::fileName, "Get the file name for this File object.")
         .def_property_readonly("url", &libOpenCOR::File::url, "Get the URL for this File object.")
-        .def_property_readonly("contents", &libOpenCOR::File::contents, "Get the contents of this File object.")
-        .def_property_readonly("size", &libOpenCOR::File::size, "Get the size of this File object.");
+        .def_property_readonly("contents", &libOpenCOR::File::contents, "Get the contents of this File object.");
 
     // Version API.
 

--- a/src/bindings/python/version.cpp
+++ b/src/bindings/python/version.cpp
@@ -1,0 +1,43 @@
+/*
+Copyright libOpenCOR contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <libopencor>
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+void versionApi(py::module_ &m)
+{
+    // Version API.
+
+    m.def("version", &libOpenCOR::version, "Get the version number of libOpenCOR.");
+    m.def("version_string", &libOpenCOR::versionString, "Get the version string of libOpenCOR.");
+    m.def("clang_version", &libOpenCOR::clangVersion, "Get the version number of Clang.");
+    m.def("clang_version_string", &libOpenCOR::clangVersionString, "Get the version string of Clang.");
+    m.def("libcellml_version", &libOpenCOR::libcellmlVersion, "Get the version number of libCellML.");
+    m.def("libcellml_version_string", &libOpenCOR::libcellmlVersionString, "Get the version string of libCellML.");
+    m.def("libcombine_version", &libOpenCOR::libcombineVersion, "Get the version number of libCOMBINE.");
+    m.def("libcombine_version_string", &libOpenCOR::libcombineVersionString, "Get the version string of libCOMBINE.");
+    m.def("libcurl_version", &libOpenCOR::libcurlVersion, "Get the version number of libcurl.");
+    m.def("libcurl_version_string", &libOpenCOR::libcurlVersionString, "Get the version string of libcurl.");
+    m.def("libsedml_version", &libOpenCOR::libsedmlVersion, "Get the version number of libSEDML.");
+    m.def("libsedml_version_string", &libOpenCOR::libsedmlVersionString, "Get the version string of libSEDML.");
+    m.def("llvm_version", &libOpenCOR::llvmVersion, "Get the version number of LLVM.");
+    m.def("llvm_version_string", &libOpenCOR::llvmVersionString, "Get the version string of LLVM.");
+    m.def("sundials_version", &libOpenCOR::sundialsVersion, "Get the version number of SUNDIALS.");
+    m.def("sundials_version_string", &libOpenCOR::sundialsVersionString, "Get the version string of SUNDIALS.");
+}

--- a/src/file_p.h
+++ b/src/file_p.h
@@ -32,14 +32,13 @@ struct File::Impl
     std::string mUrl;
 
     bool mContentsRetrieved = false;
-    char *mContents = nullptr;
-    size_t mSize = 0;
+    std::vector<unsigned char> mContents;
 
     Support::CellmlFile *mCellmlFile = nullptr;
     Support::SedmlFile *mSedmlFile = nullptr;
     Support::CombineArchive *mCombineArchive = nullptr;
 
-    Impl(const std::string &pFileNameOrUrl, const char *pContents, size_t pSize);
+    Impl(const std::string &pFileNameOrUrl, const std::vector<unsigned char> &pContents);
     ~Impl();
 
     void checkType(const FilePtr &pOwner);
@@ -48,7 +47,7 @@ struct File::Impl
     void retrieveContents();
 #endif
 
-    const char *contents();
+    std::vector<unsigned char> contents();
     size_t size();
 };
 

--- a/src/misc/compiler.cpp
+++ b/src/misc/compiler.cpp
@@ -124,7 +124,7 @@ bool Compiler::compile(const std::string &pCode)
     // Create a compiler invocation object.
 
 #ifndef COVERAGE_ENABLED
-    bool res =
+    const bool res =
 #endif
         clang::CompilerInvocation::CreateFromArgs(compilerInstance.getInvocation(),
                                                   commandArguments,

--- a/src/misc/utils.h
+++ b/src/misc/utils.h
@@ -18,8 +18,8 @@ limitations under the License.
 
 #include "unittestingexport.h"
 
-#include <memory>
 #include <string>
+#include <vector>
 
 namespace libOpenCOR {
 
@@ -28,7 +28,7 @@ bool LIBOPENCOR_UNIT_TESTING_EXPORT fuzzyCompare(double pNb1, double pNb2);
 #ifndef __EMSCRIPTEN__
 std::tuple<bool, std::string> downloadFile(const std::string &pUrl);
 
-std::tuple<bool, char *, size_t> fileContents(const std::string &pFileName);
+std::tuple<bool, std::vector<unsigned char>> fileContents(const std::string &pFileName);
 #endif
 
 } // namespace libOpenCOR

--- a/src/support/support.cpp
+++ b/src/support/support.cpp
@@ -49,7 +49,7 @@ bool isCellmlFile(const FilePtr &pFile)
 
             parser = libcellml::Parser::create(false);
 
-            parser->parseModel(reinterpret_cast<const char *>(pFile->contents().data())); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+            parser->parseModel(contents);
 
             return parser->errorCount() == 0;
         }

--- a/src/support/support.cpp
+++ b/src/support/support.cpp
@@ -27,22 +27,29 @@ limitations under the License.
 #include "libsedmlend.h"
 
 namespace libOpenCOR::Support {
+namespace {
+std::string contentsAsString(const std::vector<unsigned char> &pContents)
+{
+    return {reinterpret_cast<const char *>(pContents.data()), pContents.size()}; // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+}
+} // namespace
 
 bool isCellmlFile(const FilePtr &pFile)
 {
     // Try to parse the file contents as a CellML 2.0 file.
 
-    if (pFile->size() != 0) {
+    if (!pFile->contents().empty()) {
         auto parser = libcellml::Parser::create();
+        auto contents = contentsAsString(pFile->contents());
 
-        parser->parseModel(pFile->contents());
+        parser->parseModel(contents);
 
         if (parser->errorCount() != 0) {
             // We couldn't parse the file contents as a CellML 2.0 file, so maybe it is a CellML 1.x file?
 
             parser = libcellml::Parser::create(false);
 
-            parser->parseModel(pFile->contents());
+            parser->parseModel(reinterpret_cast<const char *>(pFile->contents().data())); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
             return parser->errorCount() == 0;
         }
@@ -77,8 +84,9 @@ bool isSedmlFile(const FilePtr &pFile)
 {
     // Try to retrieve a SED-ML document.
 
-    if (pFile->size() != 0) {
-        auto *sedmlDocument = libsedml::readSedMLFromString(pFile->contents());
+    if (!pFile->contents().empty()) {
+        auto contents = contentsAsString(pFile->contents());
+        auto *sedmlDocument = libsedml::readSedMLFromString(contents.c_str());
 
         // A non-SED-ML file results in our SED-ML document having at least one error, the first of which being of id
         // libsedml::SedNotSchemaConformant (e.g., a CellML file, i.e. an XML file, but not a SED-ML one) or

--- a/tests/bindings/javascript/file.basic.test.js
+++ b/tests/bindings/javascript/file.basic.test.js
@@ -20,46 +20,42 @@ import * as utils from "./utils.js";
 const libopencor = await libOpenCOR();
 
 describe("File basic tests", () => {
-  let someUknownContents;
   let someUknownContentsPtr;
 
-  beforeAll(async () => {
-    someUknownContents = await utils.blobToString(utils.SOME_UNKNOWN_CONTENTS);
-    someUknownContentsPtr = await utils.createBlobPtr(
+  beforeAll(() => {
+    someUknownContentsPtr = utils.allocateMemory(
       libopencor,
       utils.SOME_UNKNOWN_CONTENTS
     );
   });
 
   afterAll(() => {
-    utils.deleteBlobPtr(libopencor, someUknownContentsPtr);
+    utils.freeMemory(libopencor, someUknownContentsPtr);
   });
 
   test("Local virtual file", () => {
     const file = new libopencor.File(
       utils.LOCAL_FILE,
       someUknownContentsPtr,
-      utils.SOME_UNKNOWN_CONTENTS.size
+      utils.SOME_UNKNOWN_CONTENTS.length
     );
 
     expect(file.type().value).toBe(libopencor.File.Type.UNKNOWN_FILE.value);
     expect(file.fileName()).toBe(utils.LOCAL_FILE);
     expect(file.url()).toBe("");
-    expect(utils.arrayBufferToString(file.contents())).toBe(someUknownContents);
-    expect(file.size()).toBe(utils.SOME_UNKNOWN_CONTENTS.size);
+    expect(file.contents()).toStrictEqual(utils.SOME_UNKNOWN_CONTENTS);
   });
 
   test("Remote virtual file", () => {
     const file = new libopencor.File(
       utils.REMOTE_FILE,
       someUknownContentsPtr,
-      utils.SOME_UNKNOWN_CONTENTS.size
+      utils.SOME_UNKNOWN_CONTENTS.length
     );
 
     expect(file.type().value).toBe(libopencor.File.Type.UNKNOWN_FILE.value);
     expect(file.fileName()).toBe("");
     expect(file.url()).toBe(utils.REMOTE_FILE);
-    expect(utils.arrayBufferToString(file.contents())).toBe(someUknownContents);
-    expect(file.size()).toBe(utils.SOME_UNKNOWN_CONTENTS.size);
+    expect(file.contents()).toStrictEqual(utils.SOME_UNKNOWN_CONTENTS);
   });
 });

--- a/tests/bindings/javascript/file.coverage.test.js
+++ b/tests/bindings/javascript/file.coverage.test.js
@@ -24,11 +24,7 @@ describe("File coverage tests", () => {
     new libopencor.File(
       utils.HTTP_REMOTE_FILE,
       utils.SOME_UNKNOWN_CONTENTS,
-      utils.SOME_UNKNOWN_CONTENTS.size
+      utils.SOME_UNKNOWN_CONTENTS.length
     );
-  });
-
-  test("Not virtual file", () => {
-    new libopencor.File(utils.REMOTE_FILE, utils.SOME_UNKNOWN_CONTENTS, 0);
   });
 });

--- a/tests/bindings/javascript/file.type.test.js
+++ b/tests/bindings/javascript/file.type.test.js
@@ -24,32 +24,32 @@ describe("File type tests", () => {
   let someCellmlContentsPtr;
   let someSedmlContentsPtr;
 
-  beforeAll(async () => {
-    someUnknownContentsPtr = await utils.createBlobPtr(
+  beforeAll(() => {
+    someUnknownContentsPtr = utils.allocateMemory(
       libopencor,
       utils.SOME_UNKNOWN_CONTENTS
     );
-    someCellmlContentsPtr = await utils.createBlobPtr(
+    someCellmlContentsPtr = utils.allocateMemory(
       libopencor,
       utils.SOME_CELLML_CONTENTS
     );
-    someSedmlContentsPtr = await utils.createBlobPtr(
+    someSedmlContentsPtr = utils.allocateMemory(
       libopencor,
       utils.SOME_SEDML_CONTENTS
     );
   });
 
   afterAll(() => {
-    utils.deleteBlobPtr(libopencor, someUnknownContentsPtr);
-    utils.deleteBlobPtr(libopencor, someCellmlContentsPtr);
-    utils.deleteBlobPtr(libopencor, someSedmlContentsPtr);
+    utils.freeMemory(libopencor, someUnknownContentsPtr);
+    utils.freeMemory(libopencor, someCellmlContentsPtr);
+    utils.freeMemory(libopencor, someSedmlContentsPtr);
   });
 
   test("Unknown virtual file", () => {
     const file = new libopencor.File(
       utils.LOCAL_FILE,
       someUnknownContentsPtr,
-      utils.SOME_UNKNOWN_CONTENTS.size
+      utils.SOME_UNKNOWN_CONTENTS.length
     );
 
     expect(file.type().value).toBe(libopencor.File.Type.UNKNOWN_FILE.value);
@@ -59,7 +59,7 @@ describe("File type tests", () => {
     const file = new libopencor.File(
       utils.LOCAL_FILE,
       someCellmlContentsPtr,
-      utils.SOME_CELLML_CONTENTS.size
+      utils.SOME_CELLML_CONTENTS.length
     );
 
     expect(file.type().value).toBe(libopencor.File.Type.CELLML_FILE.value);
@@ -69,7 +69,7 @@ describe("File type tests", () => {
     const file = new libopencor.File(
       utils.LOCAL_FILE,
       someSedmlContentsPtr,
-      utils.SOME_SEDML_CONTENTS.size
+      utils.SOME_SEDML_CONTENTS.length
     );
 
     expect(file.type().value).toBe(libopencor.File.Type.SEDML_FILE.value);

--- a/tests/bindings/javascript/res/res/libopencor.js
+++ b/tests/bindings/javascript/res/res/libopencor.js
@@ -88,8 +88,7 @@ document.addEventListener("DOMContentLoaded", () => {
             }
 
             document.getElementById("fileName").innerHTML = file.name;
-            document.getElementById("fileType").innerHTML =
-              libopencorFileType + ".";
+            document.getElementById("fileType").innerHTML = libopencorFileType;
 
             updateFileUi("block", "none", "block");
           } catch (exception) {

--- a/tests/bindings/javascript/utils.js.in
+++ b/tests/bindings/javascript/utils.js.in
@@ -34,35 +34,37 @@ export const HTTP_REMOTE_FILE =
 export const REMOTE_FILE =
   "https://raw.githubusercontent.com/opencor/libopencor/master/tests/res/cellml_2.cellml";
 export const IRRETRIEVABLE_REMOTE_FILE =
-  "https://my.domain.com/irretrievable_file.txt";
+  "https://some.domain.com/irretrievable_file.txt";
 
-export const SOME_UNKNOWN_CONTENTS = new Blob(["Some unknown contents..."]);
-export const SOME_CELLML_CONTENTS = new Blob([`@SOME_CELLML_CONTENTS@`]);
-export const SOME_SEDML_CONTENTS = new Blob([`@SOME_SEDML_CONTENTS@`]);
+export const SOME_UNKNOWN_CONTENTS = stringToArrayBuffer(
+  "Some unknown contents..."
+);
+export const SOME_CELLML_CONTENTS = stringToArrayBuffer(
+  `@SOME_CELLML_CONTENTS@`
+);
+export const SOME_SEDML_CONTENTS = stringToArrayBuffer(`@SOME_SEDML_CONTENTS@`);
 
 export function resourcePath(relativePath = "") {
   return RESOURCE_LOCATION + "/" + relativePath;
 }
 
-export async function createBlobPtr(module, blob) {
-  const blobArrayBuffer = await blob.arrayBuffer();
-  const blobPtr = module._malloc(blob.size);
-  const blobMem = new Uint8Array(module.HEAPU8.buffer, blobPtr, blob.size);
+export function allocateMemory(module, arrayBuffer) {
+  const memPtr = module._malloc(arrayBuffer.length);
+  const mem = new Uint8Array(module.HEAPU8.buffer, memPtr, arrayBuffer.length);
 
-  blobMem.set(new Uint8Array(blobArrayBuffer));
+  mem.set(arrayBuffer);
 
-  return blobPtr;
+  return memPtr;
 }
 
-export async function deleteBlobPtr(module, blobPtr) {
-  module._free(blobPtr);
+export function freeMemory(module, memPtr) {
+  module._free(memPtr);
 }
 
-export async function blobToString(blob) {
-  const blobArrayBuffer = await blob.arrayBuffer();
-  const decoder = new TextDecoder();
+function stringToArrayBuffer(string) {
+  const encoder = new TextEncoder();
 
-  return decoder.decode(blobArrayBuffer);
+  return encoder.encode(string);
 }
 
 export function arrayBufferToString(arrayBuffer) {

--- a/tests/bindings/python/test_file_basic.py
+++ b/tests/bindings/python/test_file_basic.py
@@ -62,20 +62,20 @@ def test_remote_file():
 
 
 def test_local_virtual_file():
-    file = File(
-        utils.UNIX_LOCAL_FILE, utils.string_to_list(utils.SOME_UNKNOWN_CONTENTS)
-    )
+    some_unknown_contents_list = utils.string_to_list(utils.SOME_UNKNOWN_CONTENTS)
+    file = File(utils.UNIX_LOCAL_FILE, some_unknown_contents_list)
 
     assert file.type == File.Type.UnknownFile
     assert file.file_name == utils.UNIX_LOCAL_FILE
     assert file.url == ""
-    assert utils.list_to_string(file.contents) == utils.SOME_UNKNOWN_CONTENTS
+    assert file.contents == some_unknown_contents_list
 
 
 def test_remote_virtual_file():
-    file = File(utils.REMOTE_FILE, utils.string_to_list(utils.SOME_UNKNOWN_CONTENTS))
+    some_unknown_contents_list = utils.string_to_list(utils.SOME_UNKNOWN_CONTENTS)
+    file = File(utils.REMOTE_FILE, some_unknown_contents_list)
 
     assert file.type == File.Type.UnknownFile
     assert file.file_name == ""
     assert file.url == utils.REMOTE_FILE
-    assert utils.list_to_string(file.contents) == utils.SOME_UNKNOWN_CONTENTS
+    assert file.contents == some_unknown_contents_list

--- a/tests/bindings/python/test_file_basic.py
+++ b/tests/bindings/python/test_file_basic.py
@@ -22,8 +22,7 @@ def test_windows_local_file():
     assert file.type == File.Type.IrretrievableFile
     assert file.file_name == utils.WINDOWS_LOCAL_FILE
     assert file.url == ""
-    assert file.contents == None
-    assert file.size == 0
+    assert file.contents == []
 
 
 def test_unix_local_file():
@@ -32,8 +31,7 @@ def test_unix_local_file():
     assert file.type == File.Type.IrretrievableFile
     assert file.file_name == utils.UNIX_LOCAL_FILE
     assert file.url == ""
-    assert file.contents == None
-    assert file.size == 0
+    assert file.contents == []
 
 
 def test_url_based_windows_local_file():
@@ -42,8 +40,7 @@ def test_url_based_windows_local_file():
     assert file.type == File.Type.IrretrievableFile
     assert file.file_name == utils.WINDOWS_LOCAL_FILE
     assert file.url == ""
-    assert file.contents == None
-    assert file.size == 0
+    assert file.contents == []
 
 
 def test_url_based_unix_local_file():
@@ -52,8 +49,7 @@ def test_url_based_unix_local_file():
     assert file.type == File.Type.IrretrievableFile
     assert file.file_name == utils.UNIX_LOCAL_FILE
     assert file.url == ""
-    assert file.contents == None
-    assert file.size == 0
+    assert file.contents == []
 
 
 def test_remote_file():
@@ -62,31 +58,24 @@ def test_remote_file():
     assert file.type == File.Type.CellmlFile
     assert file.file_name != ""
     assert file.url == utils.REMOTE_FILE
-    assert file.contents != None
-    assert file.size != 0
+    assert file.contents != []
 
 
 def test_local_virtual_file():
     file = File(
-        utils.UNIX_LOCAL_FILE,
-        utils.SOME_UNKNOWN_CONTENTS,
-        len(utils.SOME_UNKNOWN_CONTENTS),
+        utils.UNIX_LOCAL_FILE, utils.string_to_list(utils.SOME_UNKNOWN_CONTENTS)
     )
 
     assert file.type == File.Type.UnknownFile
     assert file.file_name == utils.UNIX_LOCAL_FILE
     assert file.url == ""
-    assert file.contents == utils.SOME_UNKNOWN_CONTENTS
-    assert file.size == len(utils.SOME_UNKNOWN_CONTENTS)
+    assert utils.list_to_string(file.contents) == utils.SOME_UNKNOWN_CONTENTS
 
 
 def test_remote_virtual_file():
-    file = File(
-        utils.REMOTE_FILE, utils.SOME_UNKNOWN_CONTENTS, len(utils.SOME_UNKNOWN_CONTENTS)
-    )
+    file = File(utils.REMOTE_FILE, utils.string_to_list(utils.SOME_UNKNOWN_CONTENTS))
 
     assert file.type == File.Type.UnknownFile
     assert file.file_name == ""
     assert file.url == utils.REMOTE_FILE
-    assert file.contents == utils.SOME_UNKNOWN_CONTENTS
-    assert file.size == len(utils.SOME_UNKNOWN_CONTENTS)
+    assert utils.list_to_string(file.contents) == utils.SOME_UNKNOWN_CONTENTS

--- a/tests/bindings/python/test_file_coverage.py
+++ b/tests/bindings/python/test_file_coverage.py
@@ -22,7 +22,3 @@ def test_http_remote_file():
 
 def test_irretrievable_remote_file():
     File(utils.IRRETRIEVABLE_REMOTE_FILE)
-
-
-def test_not_virtual_file():
-    File(utils.REMOTE_FILE, utils.SOME_UNKNOWN_CONTENTS, 0)

--- a/tests/bindings/python/test_file_type.py
+++ b/tests/bindings/python/test_file_type.py
@@ -78,27 +78,19 @@ def test_type_combine_2_archive():
 
 def test_type_unknown_virtual_file():
     file = File(
-        utils.UNIX_LOCAL_FILE,
-        utils.SOME_UNKNOWN_CONTENTS,
-        len(utils.SOME_UNKNOWN_CONTENTS),
+        utils.UNIX_LOCAL_FILE, utils.string_to_list(utils.SOME_UNKNOWN_CONTENTS)
     )
 
     assert file.type == File.Type.UnknownFile
 
 
 def test_type_cellml_virtual_file():
-    file = File(
-        utils.UNIX_LOCAL_FILE,
-        utils.SOME_CELLML_CONTENTS,
-        len(utils.SOME_CELLML_CONTENTS),
-    )
+    file = File(utils.UNIX_LOCAL_FILE, utils.string_to_list(utils.SOME_CELLML_CONTENTS))
 
     assert file.type == File.Type.CellmlFile
 
 
 def test_type_sedml_virtual_file():
-    file = File(
-        utils.UNIX_LOCAL_FILE, utils.SOME_SEDML_CONTENTS, len(utils.SOME_SEDML_CONTENTS)
-    )
+    file = File(utils.UNIX_LOCAL_FILE, utils.string_to_list(utils.SOME_SEDML_CONTENTS))
 
     assert file.type == File.Type.SedmlFile

--- a/tests/bindings/python/utils.py.in
+++ b/tests/bindings/python/utils.py.in
@@ -36,7 +36,7 @@ UNIX_LOCAL_FILE = "/some/path/file.txt"
 
 HTTP_REMOTE_FILE = "http://raw.githubusercontent.com/opencor/libopencor/master/tests/res/cellml_2.cellml"
 REMOTE_FILE = "https://raw.githubusercontent.com/opencor/libopencor/master/tests/res/cellml_2.cellml"
-IRRETRIEVABLE_REMOTE_FILE = "https://my.domain.com/irretrievable_file.txt"
+IRRETRIEVABLE_REMOTE_FILE = "https://some.domain.com/irretrievable_file.txt"
 
 
 SOME_UNKNOWN_CONTENTS = "Some unknown contents..."
@@ -46,3 +46,14 @@ SOME_SEDML_CONTENTS = """@SOME_SEDML_CONTENTS@"""
 
 def resource_path(relative_path=""):
     return RESOURCE_LOCATION + "/" + relative_path
+
+
+def string_to_list(string):
+    return [ord(x) for x in string]
+
+
+def list_to_string(list):
+    if (len(list) == 0) or (list[0] == 0):
+        return ""
+
+    return chr(list[0]) + list_to_string(list[1:])

--- a/tests/bindings/python/utils.py.in
+++ b/tests/bindings/python/utils.py.in
@@ -50,10 +50,3 @@ def resource_path(relative_path=""):
 
 def string_to_list(string):
     return [ord(x) for x in string]
-
-
-def list_to_string(list):
-    if (len(list) == 0) or (list[0] == 0):
-        return ""
-
-    return chr(list[0]) + list_to_string(list[1:])

--- a/tests/file/basictests.cpp
+++ b/tests/file/basictests.cpp
@@ -27,8 +27,7 @@ TEST(BasicFileTest, windowsLocalFile)
     EXPECT_EQ(file->type(), libOpenCOR::File::Type::IRRETRIEVABLE_FILE);
     EXPECT_EQ(file->fileName(), libOpenCOR::WINDOWS_LOCAL_FILE);
     EXPECT_EQ(file->url(), "");
-    EXPECT_EQ(file->contents(), nullptr);
-    EXPECT_EQ(file->size(), 0);
+    EXPECT_TRUE(file->contents().empty());
 }
 
 TEST(BasicFileTest, unixLocalFile)
@@ -38,8 +37,7 @@ TEST(BasicFileTest, unixLocalFile)
     EXPECT_EQ(file->type(), libOpenCOR::File::Type::IRRETRIEVABLE_FILE);
     EXPECT_EQ(file->fileName(), libOpenCOR::UNIX_LOCAL_FILE);
     EXPECT_EQ(file->url(), "");
-    EXPECT_EQ(file->contents(), nullptr);
-    EXPECT_EQ(file->size(), 0);
+    EXPECT_TRUE(file->contents().empty());
 }
 
 TEST(BasicFileTest, urlBasedWindowsLocalFile)
@@ -49,8 +47,7 @@ TEST(BasicFileTest, urlBasedWindowsLocalFile)
     EXPECT_EQ(file->type(), libOpenCOR::File::Type::IRRETRIEVABLE_FILE);
     EXPECT_EQ(file->fileName(), libOpenCOR::WINDOWS_LOCAL_FILE);
     EXPECT_EQ(file->url(), "");
-    EXPECT_EQ(file->contents(), nullptr);
-    EXPECT_EQ(file->size(), 0);
+    EXPECT_TRUE(file->contents().empty());
 }
 
 TEST(BasicFileTest, urlBasedUnixLocalFile)
@@ -60,8 +57,7 @@ TEST(BasicFileTest, urlBasedUnixLocalFile)
     EXPECT_EQ(file->type(), libOpenCOR::File::Type::IRRETRIEVABLE_FILE);
     EXPECT_EQ(file->fileName(), libOpenCOR::UNIX_LOCAL_FILE);
     EXPECT_EQ(file->url(), "");
-    EXPECT_EQ(file->contents(), nullptr);
-    EXPECT_EQ(file->size(), 0);
+    EXPECT_TRUE(file->contents().empty());
 }
 
 TEST(BasicFileTest, remoteFile)
@@ -71,28 +67,27 @@ TEST(BasicFileTest, remoteFile)
     EXPECT_EQ(file->type(), libOpenCOR::File::Type::CELLML_FILE);
     EXPECT_NE(file->fileName(), "");
     EXPECT_EQ(file->url(), libOpenCOR::REMOTE_FILE);
-    EXPECT_NE(file->contents(), nullptr);
-    EXPECT_NE(file->size(), 0);
+    EXPECT_FALSE(file->contents().empty());
 }
 
 TEST(BasicFileTest, localVirtualFile)
 {
-    auto file = libOpenCOR::File::create(libOpenCOR::UNIX_LOCAL_FILE, libOpenCOR::SOME_UNKNOWN_CONTENTS, strlen(libOpenCOR::SOME_UNKNOWN_CONTENTS));
+    auto file = libOpenCOR::File::create(libOpenCOR::UNIX_LOCAL_FILE,
+                                         libOpenCOR::charArrayToVector(libOpenCOR::SOME_UNKNOWN_CONTENTS));
 
     EXPECT_EQ(file->type(), libOpenCOR::File::Type::UNKNOWN_FILE);
     EXPECT_EQ(file->fileName(), libOpenCOR::UNIX_LOCAL_FILE);
     EXPECT_EQ(file->url(), "");
-    EXPECT_TRUE(!strcmp(file->contents(), libOpenCOR::SOME_UNKNOWN_CONTENTS));
-    EXPECT_EQ(file->size(), strlen(libOpenCOR::SOME_UNKNOWN_CONTENTS));
+    EXPECT_TRUE(!strcmp(reinterpret_cast<const char *>(file->contents().data()), libOpenCOR::SOME_UNKNOWN_CONTENTS));
 }
 
 TEST(BasicFileTest, remoteVirtualFile)
 {
-    auto file = libOpenCOR::File::create(libOpenCOR::REMOTE_FILE, libOpenCOR::SOME_UNKNOWN_CONTENTS, strlen(libOpenCOR::SOME_UNKNOWN_CONTENTS));
+    auto file = libOpenCOR::File::create(libOpenCOR::REMOTE_FILE,
+                                         libOpenCOR::charArrayToVector(libOpenCOR::SOME_UNKNOWN_CONTENTS));
 
     EXPECT_EQ(file->type(), libOpenCOR::File::Type::UNKNOWN_FILE);
     EXPECT_EQ(file->fileName(), "");
     EXPECT_EQ(file->url(), libOpenCOR::REMOTE_FILE);
-    EXPECT_TRUE(!strcmp(file->contents(), libOpenCOR::SOME_UNKNOWN_CONTENTS));
-    EXPECT_EQ(file->size(), strlen(libOpenCOR::SOME_UNKNOWN_CONTENTS));
+    EXPECT_TRUE(!strcmp(reinterpret_cast<const char *>(file->contents().data()), libOpenCOR::SOME_UNKNOWN_CONTENTS));
 }

--- a/tests/file/basictests.cpp
+++ b/tests/file/basictests.cpp
@@ -72,22 +72,22 @@ TEST(BasicFileTest, remoteFile)
 
 TEST(BasicFileTest, localVirtualFile)
 {
-    auto file = libOpenCOR::File::create(libOpenCOR::UNIX_LOCAL_FILE,
-                                         libOpenCOR::charArrayToVector(libOpenCOR::SOME_UNKNOWN_CONTENTS));
+    auto someUnknownContentsVector = libOpenCOR::charArrayToVector(libOpenCOR::SOME_UNKNOWN_CONTENTS);
+    auto file = libOpenCOR::File::create(libOpenCOR::UNIX_LOCAL_FILE, someUnknownContentsVector);
 
     EXPECT_EQ(file->type(), libOpenCOR::File::Type::UNKNOWN_FILE);
     EXPECT_EQ(file->fileName(), libOpenCOR::UNIX_LOCAL_FILE);
     EXPECT_EQ(file->url(), "");
-    EXPECT_TRUE(!strcmp(reinterpret_cast<const char *>(file->contents().data()), libOpenCOR::SOME_UNKNOWN_CONTENTS));
+    EXPECT_EQ(file->contents(), someUnknownContentsVector);
 }
 
 TEST(BasicFileTest, remoteVirtualFile)
 {
-    auto file = libOpenCOR::File::create(libOpenCOR::REMOTE_FILE,
-                                         libOpenCOR::charArrayToVector(libOpenCOR::SOME_UNKNOWN_CONTENTS));
+    auto someUnknownContentsVector = libOpenCOR::charArrayToVector(libOpenCOR::SOME_UNKNOWN_CONTENTS);
+    auto file = libOpenCOR::File::create(libOpenCOR::REMOTE_FILE, someUnknownContentsVector);
 
     EXPECT_EQ(file->type(), libOpenCOR::File::Type::UNKNOWN_FILE);
     EXPECT_EQ(file->fileName(), "");
     EXPECT_EQ(file->url(), libOpenCOR::REMOTE_FILE);
-    EXPECT_TRUE(!strcmp(reinterpret_cast<const char *>(file->contents().data()), libOpenCOR::SOME_UNKNOWN_CONTENTS));
+    EXPECT_EQ(file->contents(), someUnknownContentsVector);
 }

--- a/tests/file/coveragetests.cpp
+++ b/tests/file/coveragetests.cpp
@@ -29,8 +29,3 @@ TEST(CoverageTest, irretrievableRemoteFile)
 {
     libOpenCOR::File::create(libOpenCOR::IRRETRIEVABLE_REMOTE_FILE);
 }
-
-TEST(CoverageTest, notVirtualFile)
-{
-    libOpenCOR::File::create(libOpenCOR::REMOTE_FILE, libOpenCOR::SOME_UNKNOWN_CONTENTS, 0);
-}

--- a/tests/file/typetests.cpp
+++ b/tests/file/typetests.cpp
@@ -92,21 +92,24 @@ TEST(TypeFileTest, combine2Archive)
 
 TEST(TypeFileTest, unknownVirtualFile)
 {
-    auto file = libOpenCOR::File::create(libOpenCOR::UNIX_LOCAL_FILE, libOpenCOR::SOME_UNKNOWN_CONTENTS, strlen(libOpenCOR::SOME_UNKNOWN_CONTENTS));
+    auto file = libOpenCOR::File::create(libOpenCOR::UNIX_LOCAL_FILE,
+                                         libOpenCOR::charArrayToVector(libOpenCOR::SOME_UNKNOWN_CONTENTS));
 
     EXPECT_EQ(file->type(), libOpenCOR::File::Type::UNKNOWN_FILE);
 }
 
 TEST(TypeFileTest, cellmlVirtualFile)
 {
-    auto file = libOpenCOR::File::create(libOpenCOR::UNIX_LOCAL_FILE, libOpenCOR::SOME_CELLML_CONTENTS, strlen(libOpenCOR::SOME_CELLML_CONTENTS));
+    auto file = libOpenCOR::File::create(libOpenCOR::UNIX_LOCAL_FILE,
+                                         libOpenCOR::charArrayToVector(libOpenCOR::SOME_CELLML_CONTENTS));
 
     EXPECT_EQ(file->type(), libOpenCOR::File::Type::CELLML_FILE);
 }
 
 TEST(TypeFileTest, sedmlVirtualFile)
 {
-    auto file = libOpenCOR::File::create(libOpenCOR::UNIX_LOCAL_FILE, libOpenCOR::SOME_SEDML_CONTENTS, strlen(libOpenCOR::SOME_SEDML_CONTENTS));
+    auto file = libOpenCOR::File::create(libOpenCOR::UNIX_LOCAL_FILE,
+                                         libOpenCOR::charArrayToVector(libOpenCOR::SOME_SEDML_CONTENTS));
 
     EXPECT_EQ(file->type(), libOpenCOR::File::Type::SEDML_FILE);
 }

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -16,11 +16,25 @@ limitations under the License.
 
 #include "tests/utils.h"
 
+#include <cstring>
+
 namespace libOpenCOR {
 
 std::string resourcePath(const std::string &resourceRelativePath)
 {
     return std::string(RESOURCE_LOCATION) + "/" + resourceRelativePath;
+}
+
+#ifdef __clang__
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+#endif
+std::vector<unsigned char> charArrayToVector(const char *contents)
+#ifdef __clang__
+#    pragma clang diagnostic pop
+#endif
+{
+    return {contents, contents + strlen(contents)}; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 }
 
 } // namespace libOpenCOR

--- a/tests/utils.h.in
+++ b/tests/utils.h.in
@@ -17,6 +17,7 @@ limitations under the License.
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace libOpenCOR {
 
@@ -38,12 +39,14 @@ inline constexpr auto UNIX_LOCAL_FILE = "/some/path/file.txt";
 
 inline constexpr auto HTTP_REMOTE_FILE = "http://raw.githubusercontent.com/opencor/libopencor/master/tests/res/cellml_2.cellml";
 inline constexpr auto REMOTE_FILE = "https://raw.githubusercontent.com/opencor/libopencor/master/tests/res/cellml_2.cellml";
-inline constexpr auto IRRETRIEVABLE_REMOTE_FILE = "https://my.domain.com/irretrievable_file.txt";
+inline constexpr auto IRRETRIEVABLE_REMOTE_FILE = "https://some.domain.com/irretrievable_file.txt";
 
 inline constexpr auto SOME_UNKNOWN_CONTENTS = "Some unknown contents...";
 inline constexpr auto SOME_CELLML_CONTENTS = "@SOME_CELLML_CONTENTS_C@";
 inline constexpr auto SOME_SEDML_CONTENTS = "@SOME_SEDML_CONTENTS_C@";
 
 std::string resourcePath(const std::string &resourceRelativePath);
+
+std::vector<unsigned char> charArrayToVector(const char *contents);
 
 } // namespace libOpenCOR


### PR DESCRIPTION
Fixes #220.