### PR TITLE
LLVM+Clang: don't have a dependency on `libclang`

### DIFF
--- a/src/3rdparty/LLVMClang/CMakeLists.txt
+++ b/src/3rdparty/LLVMClang/CMakeLists.txt
@@ -225,7 +225,6 @@ set(LLVMCLANG_LIBRARIES
     clangToolingRefactoring
     clangToolingSyntax
     clangTransformer
-    libclang
     LLVMAggressiveInstCombine
     LLVMAnalysis
     LLVMAsmParser


### PR DESCRIPTION
Fixes #382.