### PR TITLE
CMake: if possible, extract `.obj` files from a `.lib` file using 7-Zip

### DIFF
--- a/cmake/environmentchecks.cmake
+++ b/cmake/environmentchecks.cmake
@@ -145,6 +145,7 @@ if(NOT BUILDCACHE_EXE)
     endif()
 endif()
 
+find_program(7Z_EXE NAMES ${PREFERRED_7Z_NAMES} 7z)
 find_program(BLACK_EXE NAMES ${PREFERRED_BLACK_NAMES} black)
 find_program(CLANG_FORMAT_EXE NAMES ${PREFERRED_CLANG_FORMAT_NAMES} clang-format)
 find_program(CLANG_TIDY_EXE NAMES ${PREFERRED_CLANG_TIDY_NAMES} clang-tidy)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -350,20 +350,25 @@ else()
             file(MAKE_DIRECTORY ${PACKAGE_DIR})
 
             if(WIN32)
-                execute_process(COMMAND ${CMAKE_AR} /NOLOGO /LIST ${PACKAGE}
-                                OUTPUT_VARIABLE PACKAGE_FILES
-                                OUTPUT_STRIP_TRAILING_WHITESPACE)
+                if(7Z_EXE)
+                    execute_process(COMMAND ${7Z_EXE} e ${PACKAGE} -bso0
+                                    WORKING_DIRECTORY ${PACKAGE_DIR})
+                else()
+                    execute_process(COMMAND ${CMAKE_AR} /NOLOGO /LIST ${PACKAGE}
+                                    OUTPUT_VARIABLE PACKAGE_FILES
+                                    OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-                string(REPLACE "\n" ";" PACKAGE_FILES ${PACKAGE_FILES})
+                    string(REPLACE "\n" ";" PACKAGE_FILES ${PACKAGE_FILES})
 
-                foreach(PACKAGE_FILE ${PACKAGE_FILES})
-                    string(REGEX MATCH ".*\\${CMAKE_CXX_OUTPUT_EXTENSION}$" IS_OBJECT_FILE ${PACKAGE_FILE})
+                    foreach(PACKAGE_FILE ${PACKAGE_FILES})
+                        string(REGEX MATCH ".*\\${CMAKE_CXX_OUTPUT_EXTENSION}$" IS_OBJECT_FILE ${PACKAGE_FILE})
 
-                    if(IS_OBJECT_FILE)
-                        execute_process(COMMAND ${CMAKE_AR} /NOLOGO /EXTRACT:${PACKAGE_FILE} ${PACKAGE}
-                                        WORKING_DIRECTORY ${PACKAGE_DIR})
-                    endif()
-                endforeach()
+                        if(IS_OBJECT_FILE)
+                            execute_process(COMMAND ${CMAKE_AR} /NOLOGO /EXTRACT:${PACKAGE_FILE} ${PACKAGE}
+                                            WORKING_DIRECTORY ${PACKAGE_DIR})
+                        endif()
+                    endforeach()
+                endif()
             else()
                 execute_process(COMMAND ${CMAKE_AR} -x ${PACKAGE}
                                 WORKING_DIRECTORY ${PACKAGE_DIR})


### PR DESCRIPTION
Fixes #439.